### PR TITLE
Use $GITHUB_ENV instead of add-path

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir -p $HOME/bin
         curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b $HOME/bin
-        echo ::add-path::$HOME/bin
+        echo "$HOME/bin" >> $GITHUB_PATH
 
     - run: gem install bundler -v 2.1.4
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -28,6 +28,8 @@ jobs:
     - run: bundle install --jobs 4 --retry 3
 
     - name: Run Rubocop with Reviewdog
+      env:
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bundle exec rubocop --fail-level E \
           | reviewdog -f=rubocop -reporter=github-pr-review


### PR DESCRIPTION
## Why

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
`add-path` is deprecated.

## What

Use `$GITHUB_PATH` instead.