### PR TITLE
Bump computed_model from 0.2.2 to 0.3.0

### DIFF
--- a/pb-serializer.gemspec
+++ b/pb-serializer.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   rails_versions = [">= 5.2", "< 6.1"]
   spec.add_runtime_dependency "google-protobuf", "~> 3.0"
   spec.add_runtime_dependency "the_pb", "~> 0.0.1"
-  spec.add_runtime_dependency "computed_model", "~> 0.2.2"
+  spec.add_runtime_dependency "computed_model", "~> 0.3.0"
 
   spec.add_development_dependency "activerecord", rails_versions
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/spec/examples/composite_model_spec.rb
+++ b/spec/examples/composite_model_spec.rb
@@ -60,12 +60,13 @@ RSpec.describe 'composite AR models into 1 message' do
 
       delegate_dependency :avatar_url, to: :profile
       delegate_dependency :birthday,   to: :profile
-      delegate_dependency :skills,     to: :profile, prefix: :_, include_subdeps: true
+      delegate_dependency :skills,     to: :profile, prefix: :_, include_subfields: true
 
       define_primary_loader :user do |subdeps, ids:, **|
         User.where(id: ids).preload(subdeps).map { |u| new(u) }
       end
 
+      dependency :user
       define_loader :profile, key: -> { id } do |keys, subdeps, **|
         Profile.where(user_id: keys).preload(subdeps).index_by(&:user_id)
       end
@@ -75,7 +76,7 @@ RSpec.describe 'composite AR models into 1 message' do
         profile.name
       end
 
-      dependency :profile
+      dependency :profile, :birthday
       computed def age
         return nil if birthday.nil?
         [TODAY, birthday].map {|d| d.strftime("%Y%m%d").to_i }.yield_self {|(t, b)| t - b } / 10000

--- a/spec/examples/extend_initialization_spec.rb
+++ b/spec/examples/extend_initialization_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'extend initialize method with `define_primary_loader`' do
 
       attribute :name
 
-      delegate_dependency :names, to: :user, prefix: :_, include_subdeps: true
+      delegate_dependency :names, to: :user, prefix: :_, include_subfields: true
 
       def initialize(_, locale)
         super

--- a/spec/examples/has_many_spec.rb
+++ b/spec/examples/has_many_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'has_many association' do
     module self::Sandbox
       class UserSerializer < Pb::Serializer::Base
         attribute :posts, serializer: PostSerializer
-        delegate_dependency :posts, to: :user, include_subdeps: true
+        delegate_dependency :posts, to: :user, include_subfields: true
       end
     end
   end
@@ -118,6 +118,7 @@ RSpec.describe 'has_many association' do
 
     module self::Sandbox
       class UserSerializer < Pb::Serializer::Base
+        dependency :user
         define_loader :posts, key: -> { id } do |user_ids, subdeps, **|
           PostSerializer.bulk_load(user_ids: user_ids, with: subdeps).group_by { |s| s.post.user_id }
         end

--- a/spec/examples/has_many_through_spec.rb
+++ b/spec/examples/has_many_through_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'has_many_through associaitons' do
     module self::Sandbox
       class PostSerializer < Pb::Serializer::Base
         attribute :tags, serializer: TagSerializer
-        delegate_dependency :tags, to: :post, include_subdeps: true
+        delegate_dependency :tags, to: :post, include_subfields: true
       end
     end
   end
@@ -98,6 +98,7 @@ RSpec.describe 'has_many_through associaitons' do
       class PostSerializer < Pb::Serializer::Base
         attribute :tags
 
+        dependency :post
         define_loader :tags, key: -> { id } do |post_ids, subdeps, **|
           taggings = PostTagging.where(post_id: post_ids).pluck(:tag_id, :post_id).each_with_object({}) { |(t_id, p_id) ,h| (h[p_id] ||= []) << t_id }
           tags = TagSerializer.bulk_load(with: subdeps, ids: taggings.values.flatten).index_by { |s| s.tag.id }

--- a/spec/examples/oneof_spec.rb
+++ b/spec/examples/oneof_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe 'oneof field' do
       attribute :name
       attribute :accounts, serializer: AccountSerializer
 
-      delegate_dependency :github_accounts,  to: :user, include_subdeps: true
-      delegate_dependency :twitter_accounts, to: :user, include_subdeps: true
+      delegate_dependency :github_accounts,  to: :user, include_subfields: true
+      delegate_dependency :twitter_accounts, to: :user, include_subfields: true
 
       define_primary_loader :user do |subdeps, ids:, **|
         User.where(id: ids).preload(subdeps).map { |u| new(u) }


### PR DESCRIPTION
## Why

Just released computed_model 0.3.0. We first want to spread it internally, but pb-serializer is the blocker here.

## What

Bumped computed_model to 0.3.0 and fixed tests, but I'm not sure this is the correct fix. @izumin5210 what do you think about it?

Reference: [computed_model 0.3.0 migration guide](https://github.com/wantedly/computed_model/blob/v0.3.0/Migration-0.3.md)