### PR TITLE
Stop defining accessor methods in `attribute` DSL if the method of the same name already existss

### DIFF
--- a/lib/pb/serializer/dsl.rb
+++ b/lib/pb/serializer/dsl.rb
@@ -27,8 +27,10 @@ module Pb
         @attr_by_name ||= {}
         @attr_by_name[name] = attr
 
-        define_method attr.name do
-          primary_object.public_send(attr.name)
+        unless method_defined?(attr.name)
+          define_method attr.name do
+            primary_object.public_send(attr.name)
+          end
         end
       end
 


### PR DESCRIPTION
for improving interoperability with computed_model