### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.6.0
+
+- Change default value of `missing_field_behavior` from `:raise` to `:ignore` https://github.com/wantedly/pb-serializer/pull/56
+- Update CI Ruby versions to 3.0+ https://github.com/wantedly/pb-serializer/pull/56
+- Update `simplecov-cobertura` to latest version https://github.com/wantedly/pb-serializer/pull/56
+
 ## 0.5.2
 
 - Generate the default mask lazily to prevent infinite recursions https://github.com/wantedly/pb-serializer/pull/52
@@ -26,14 +32,13 @@
 
 - Support `if` option https://github.com/wantedly/pb-serializer/pull/24
 - Improve error handling https://github.com/wantedly/pb-serializer/pull/26
-    - raise `MissingMessageTypeError` if `message` declaration is missed
-    - raise `MissingFieldError` if `attribute` declaration is missed
-    - raise `InvalidOptionError` when `attribute` receives invalid params
+  - raise `MissingMessageTypeError` if `message` declaration is missed
+  - raise `MissingFieldError` if `attribute` declaration is missed
+  - raise `InvalidOptionError` when `attribute` receives invalid params
 - Introduce Pb::Serializer.configure https://github.com/wantedly/pb-serializer/pull/27
-    - Add `missing_field_behavior` config to suppress `MissingFieldError`
-    - Rename `InvalidOptionError` -> `InvalidAttributeOptionError`
+  - Add `missing_field_behavior` config to suppress `MissingFieldError`
+  - Rename `InvalidOptionError` -> `InvalidAttributeOptionError`
 - Skip serializing when a value is already serialized https://github.com/wantedly/pb-serializer/pull/29
-
 
 ## 0.2.1
 
@@ -47,7 +52,6 @@
   - Bump `computed_model` from 0.1.0 to 0.2.1
   - Change API
 - Add example specs https://github.com/wantedly/pb-serializer/pull/18
-
 
 ## 0.1.0
 

--- a/lib/pb/serializer/version.rb
+++ b/lib/pb/serializer/version.rb
@@ -1,5 +1,5 @@
 module Pb
   module Serializer
-    VERSION = "0.5.2".freeze
+    VERSION = "0.6.0".freeze
   end
 end


### PR DESCRIPTION
## Why

We would like to release the feature of https://github.com/wantedly/pb-serializer/pull/56

## What

Release the version 0.6.0


## TODO

* [リリース作業](https://github.com/wantedly/pb-serializer?tab=readme-ov-file#development)
  * この後の作業は以下を想定
    * git checkout master 
    * git pull origin master (0.6.0を取り込んだ状態にする)
    * bundle exec rake release
  * [参考](https://wantedly.slack.com/archives/C03H8TUN2D9/p1695617540706819) 

* 各リポジトリで取り込む
  * https://github.com/search?q=org%3Awantedly+pb-serializer+path%3AGemfile.lock+NOT+is%3Aarchived&type=code
  * pb-serializerに依存するリポジトリを全てbundle update